### PR TITLE
qqplot change

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,4 +53,4 @@ License: Artistic-2.0
 URL: http://github.com/perishky/ewaff
 LazyData: yes
 biocViews: DNAMethylation, Microarray
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.1

--- a/man/ewaff.qq.plot.Rd
+++ b/man/ewaff.qq.plot.Rd
@@ -28,7 +28,7 @@ ewaff.qq.plot(
 \item{ylab}{Label for the y-axis (Default: -log_10(observed p-values)).}
 
 \item{lambda.method}{Method for calculating genomic inflation lambda.
-Valid values are "median", "regression", or "robust" (Default: "median").}
+Valid values are "median", "regression", "robust", or "none" (Default: "median"). A value of "none" will prevent the lambda value being displayed on the plot.}
 }
 \value{
 An \code{\link{ggplot}} object.


### PR DESCRIPTION
updated qqplot so that having the lambda present on the plot is a choice - to help when plotting multiple qqplots together and the text wont fit. Unfortunately, the text size of ggplot can't be easily changed or removed when it comes from annotate() or geom_text() as they aren't modifiable using the theme() function. I've tested the new function and it works locally for me.